### PR TITLE
feat: include current idx when rendering header or footer

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -302,8 +302,8 @@ var ImageCarousel = function (_React$Component) {
 
       var opacity = _this.getFullscreenOpacity();
 
-      var header = renderHeader && renderHeader();
-      var footer = renderFooter && renderFooter();
+      var header = renderHeader && renderHeader(selectedIdx);
+      var footer = renderFooter && renderFooter(selectedIdx);
 
       return React.createElement(
         reactNative.Modal,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-carousel",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Image carousel with support for fullscreen mode with swiping and pinch-to-zoom.",
   "homepage": "https://github.com/anvilabs/react-native-image-carousel",
   "author": "Binur Konarbai <binchik@anvilabs.co>",

--- a/src/index.js
+++ b/src/index.js
@@ -32,8 +32,8 @@ type PropsType = {|
   children?: React.Element<*> | $ReadOnlyArray<React.Element<*>>,
   zoomEnabled: boolean,
   hideStatusBarOnOpen: boolean,
-  renderHeader?: ?() => React.Element<*>,
-  renderFooter?: ?() => React.Element<*>,
+  renderHeader?: ?(idx: number) => React.Element<*>,
+  renderFooter?: ?(idx: number) => React.Element<*>,
   renderContent?: ?(idx: number) => React.Element<*>,
   onIdxChange?: ?(idx: number) => void,
   onOpen?: ?() => void,
@@ -380,8 +380,8 @@ class ImageCarousel extends React.Component<PropsType, StateType> {
 
     const opacity = this.getFullscreenOpacity();
 
-    const header = renderHeader && renderHeader();
-    const footer = renderFooter && renderFooter();
+    const header = renderHeader && renderHeader(selectedIdx);
+    const footer = renderFooter && renderFooter(selectedIdx);
 
     return (
       <Modal


### PR DESCRIPTION
Implemented passing current idx to renderHeader and renderFooter methods.

It might be needed in situations where one would like to display current picture data in header or footer (in my example I need picture name displayed in footer)